### PR TITLE
responsive figs

### DIFF
--- a/layout/css/main.css
+++ b/layout/css/main.css
@@ -28,7 +28,6 @@ header img{
 	}
 
 .svgFig {
-	width: 760px;
 	position: relative;
   left: 50%;
   -webkit-transform: translateX(-50%);
@@ -135,6 +134,10 @@ footer{
 	header h3{
 		padding-top:0;
 		font-size:1.2em;
+	}
+	
+	.svgFig {
+	  width: 760px;
 	}
 		
 	/*Keynote CSS*/	


### PR DESCRIPTION
@jread-usgs 
.svgFig had a width declaration on it in the mobile CSS area, removed it from the mobile area and inside the media query for 768px. The svg now responds to all screen sizes. 
