### PR TITLE
wisconsin figure not huge on mobile

### DIFF
--- a/layout/css/main.css
+++ b/layout/css/main.css
@@ -102,6 +102,7 @@ a:link {
 	}
 	
 .svgFig{
+  width:100%;
   min-height:200px !important;
 }
 	


### PR DESCRIPTION
@jread-usgs This is to just make sure the Wisconsin figure doesn't create horizontal scrolling on mobile
